### PR TITLE
Fix build constraints

### DIFF
--- a/syscalls_other.go
+++ b/syscalls_other.go
@@ -1,4 +1,4 @@
-// +build NOT (linux OR darwin)
+// +build !(linux | darwin)
 
 package water
 

--- a/syscalls_other.go
+++ b/syscalls_other.go
@@ -1,4 +1,4 @@
-// +build !(linux | darwin)
+// +build !linux,!darwin
 
 package water
 


### PR DESCRIPTION
`// +build NOT (linux OR darwin)` doesnt work at all, so buld under windows didnt include newTAP()/newTUN() funcs.