### PR TITLE
darwin: Detect IP Version for NULL Header on Write

### DIFF
--- a/syscalls_darwin.go
+++ b/syscalls_darwin.go
@@ -151,6 +151,11 @@ func (t *tunReadCloser) Read(to []byte) (int, error) {
 }
 
 func (t *tunReadCloser) Write(from []byte) (int, error) {
+
+	if len(from) == 0 {
+		return 0, syscall.EIO
+	}
+
 	t.wMu.Lock()
 	defer t.wMu.Unlock()
 

--- a/syscalls_darwin.go
+++ b/syscalls_darwin.go
@@ -159,7 +159,16 @@ func (t *tunReadCloser) Write(from []byte) (int, error) {
 	}
 	t.wBuf = t.wBuf[:len(from)+4]
 
-	t.wBuf[3] = 2 // Family: IP (2)
+	// Determine the IP Family for the NULL L2 Header
+	ipVer := from[0] >> 4
+	if ipVer == 4 {
+		t.wBuf[3] = syscall.AF_INET
+	} else if ipVer == 6 {
+		t.wBuf[3] = syscall.AF_INET6
+	} else {
+		return 0, errors.New("Unable to determine IP version from packet.")
+	}
+
 	copy(t.wBuf[4:], from)
 
 	n, err := t.f.Write(t.wBuf)


### PR DESCRIPTION
Currently, IPv6 traffic is dropped by the kernel due to the NULL header having the wrong family set (always set to AF_INET). 

This change adds the ability for both IPv4 and IPv6 to be written to the TUN device on macOS by inspecting the packet's version field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/songgao/water/24)
<!-- Reviewable:end -->
