### PR TITLE
fix for mips compile

### DIFF
--- a/syscalls_linux.go
+++ b/syscalls_linux.go
@@ -22,7 +22,7 @@ type ifReq struct {
 	pad   [0x28 - 0x10 - 2]byte
 }
 
-func ioctl(fd uintptr, request int, argp uintptr) error {
+func ioctl(fd uintptr, request uint, argp uintptr) error {
 	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(request), argp)
 	if errno != 0 {
 		return os.NewSyscallError("ioctl", errno)


### PR DESCRIPTION
issue detail : https://github.com/golang/go/issues/21596
const is untyped int