### PR TITLE
OpenBSD (and possibly FreeBSD) support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@ Tony Lu <tonyluj@gmail.com>
 ajee cai <ajee.cai@gmail.com>
 yinheli <hi@yinheli.com>
 Paul Querna <pquerna@apache.org>
+Neil Alexander <neilalexander@users.noreply.github.com>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See https://github.com/songgao/packets for functions for parsing various packets
 * Linux
 * Windows (experimental; APIs might change)
 * macOS (point-to-point TUN only)
+* OpenBSD
 
 ## Installation
 ```

--- a/ipv4_test.go
+++ b/ipv4_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/songgao/water/waterutil"
+	"./waterutil"
 )
 
 const BUFFERSIZE = 1522

--- a/params_bsd.go
+++ b/params_bsd.go
@@ -1,0 +1,20 @@
+// +build openbsd freebsd
+
+package water
+
+// PlatformSpecificParams defines parameters in Config that are specific to
+// Linux. A zero-value of such type is valid, yielding an interface
+// with OS defined name.
+type PlatformSpecificParams struct {
+	// Name is the name to be set for the interface to be created. This overrides
+	// the default name assigned by OS such as tap0 or tun0. A zero-value of this
+	// field, i.e. an empty string, indicates that the default name should be
+	// used.
+	Name string
+}
+
+func defaultPlatformSpecificParams() PlatformSpecificParams {
+	return PlatformSpecificParams{
+		Name: "/dev/tun0",
+	}
+}

--- a/params_others.go
+++ b/params_others.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!windows
+// +build !linux,!darwin,!windows,!openbsd,!freebsd
 
 package water
 

--- a/syscalls_bsd.go
+++ b/syscalls_bsd.go
@@ -1,0 +1,54 @@
+// +build openbsd freebsd
+
+package water
+
+import (
+	"os"
+	"syscall"
+)
+
+const bsdTUNSIFINFO = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 91
+const bsdTUNSIFMODE = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 94
+
+type tuninfo struct {
+	BaudRate int
+	MTU      int16
+	Type     uint8
+	Dummy    uint8
+}
+
+func ioctl(fd uintptr, request uintptr, argp uintptr) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, request, argp)
+	if errno != 0 {
+		return os.NewSyscallError("ioctl", errno)
+	}
+	return nil
+}
+
+func newTAP(config Config) (ifce *Interface, err error) {
+	if config.Name[:8] != "/dev/tap" {
+		panic("TUN/TAP name must be in format /dev/tunX or /dev/tapX")
+	}
+
+	file, err := os.OpenFile(config.Name, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	ifce = &Interface{isTAP: true, ReadWriteCloser: file, name: config.Name[5:]}
+	return
+}
+
+func newTUN(config Config) (ifce *Interface, err error) {
+	if config.Name[:8] != "/dev/tun" {
+		panic("TUN/TAP name must be in format /dev/tunX or /dev/tapX")
+	}
+
+	file, err := os.OpenFile(config.Name, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	ifce = &Interface{isTAP: false, ReadWriteCloser: file, name: config.Name[5:]}
+	return
+}

--- a/syscalls_other.go
+++ b/syscalls_other.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!windows
+// +build !linux,!darwin,!windows,!openbsd,!freebsd
 
 package water
 


### PR DESCRIPTION
This adds support for OpenBSD (tested) and also possibly FreeBSD (untested, but builds without error).

With some very minor tweaks, this code could also potentially support NetBSD, DragonflyBSD and Solaris. 