### PR TITLE
 Add support for Windows to allow selecting between multiple `tap0901` adapters on the same system

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,3 +10,4 @@ ajee cai <ajee.cai@gmail.com>
 yinheli <hi@yinheli.com>
 Paul Querna <pquerna@apache.org>
 Cuong Manh Le <cuong.manhle.vn@gmail.com>
+Neil Alexander <neilalexander@users.noreply.github.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,3 +11,4 @@ yinheli <hi@yinheli.com>
 Paul Querna <pquerna@apache.org>
 Cuong Manh Le <cuong.manhle.vn@gmail.com>
 Neil Alexander <neilalexander@users.noreply.github.com>
+Dmitry Shihovtsev <soffokulus@gmail.com>

--- a/README.md
+++ b/README.md
@@ -220,6 +220,21 @@ ping 10.1.0.255
 
 You'll see output containing the IPv4 ICMP frame same as the Linux version.
 
+#### Specifying interface name
+
+If you are going to use multiple TAP devices on the Windows, there is a way to specify an interface name to select the exact device that you need:
+
+```go
+	ifce, err := water.New(water.Config{
+		DeviceType: water.TAP,
+		PlatformSpecificParams: water.PlatformSpecificParams{
+			ComponentID:   "tap0901",
+			InterfaceName: "Ethernet 3",
+			Network:       "192.168.1.10/24",
+		},
+	})
+```
+
 ## TODO
 * tuntaposx for TAP on Darwin
 

--- a/params_windows.go
+++ b/params_windows.go
@@ -9,9 +9,9 @@ type PlatformSpecificParams struct {
 	// use the default ComponentId. The default ComponentId is set to tap0901,
 	// the one used by OpenVPN.
 	ComponentID string
+	// InterfaceName is a friendly name of the network adapter as set in Control Panel.
 	// Of course, you may have multiple tap0901 adapters on the system, in which
-	// case we need a friendlier way to identify them. In that case we can use
-	// the friendly name of the network adapter as set in Control Panel.
+	// case we need a friendlier way to identify them.
 	InterfaceName string
 	// Network is required when creating a TUN interface. The library will call
 	// net.ParseCIDR() to parse this string into LocalIP, RemoteNetaddr,
@@ -29,7 +29,6 @@ type PlatformSpecificParams struct {
 func defaultPlatformSpecificParams() PlatformSpecificParams {
 	return PlatformSpecificParams{
 		ComponentID: "tap0901",
-		InterfaceName: "",
 		Network:     "192.168.1.10/24",
 	}
 }

--- a/params_windows.go
+++ b/params_windows.go
@@ -9,6 +9,10 @@ type PlatformSpecificParams struct {
 	// use the default ComponentId. The default ComponentId is set to tap0901,
 	// the one used by OpenVPN.
 	ComponentID string
+	// Of course, you may have multiple tap0901 adapters on the system, in which
+	// case we need a friendlier way to identify them. In that case we can use
+	// the friendly name of the network adapter as set in Control Panel.
+	InterfaceName string
 	// Network is required when creating a TUN interface. The library will call
 	// net.ParseCIDR() to parse this string into LocalIP, RemoteNetaddr,
 	// RemoteNetmask. The underlying driver will need those to generate ARP
@@ -25,6 +29,7 @@ type PlatformSpecificParams struct {
 func defaultPlatformSpecificParams() PlatformSpecificParams {
 	return PlatformSpecificParams{
 		ComponentID: "tap0901",
+		InterfaceName: "",
 		Network:     "192.168.1.10/24",
 	}
 }


### PR DESCRIPTION
This PR is based on the original https://github.com/songgao/water/pull/37 from @neilalexander, but contains only support for Windows to allow selecting between multiple `tap0901` adapters on the same system. 

It also contains styling fixes based on the original PR review.