### PR TITLE
fix pre-go1.11 and other cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 water.test
+water.test.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
-  - "1.11.4"
+  - "1.12.1"
+  - "1.10.8"
 go_import_path: github.com/songgao/water
 install: go get -u golang.org/x/lint/golint
 script: make ci

--- a/if.go
+++ b/if.go
@@ -57,10 +57,8 @@ func New(config Config) (ifce *Interface, err error) {
 		config.PlatformSpecificParams = defaultPlatformSpecificParams()
 	}
 	switch config.DeviceType {
-	case TUN:
-		return newTUN(config)
-	case TAP:
-		return newTAP(config)
+	case TUN, TAP:
+		return openDev(config)
 	default:
 		return nil, errors.New("unknown device type")
 	}

--- a/if_linux.go
+++ b/if_linux.go
@@ -14,7 +14,7 @@ func NewTAP(ifName string) (ifce *Interface, err error) {
 	fmt.Println("Deprecated: NewTAP(..) may be removed in the future. Please use New() instead.")
 	config := Config{DeviceType: TAP}
 	config.Name = ifName
-	return newTAP(config)
+	return openDev(config)
 }
 
 // NewTUN creates a new TUN interface whose name is ifName. If ifName is empty, a
@@ -26,5 +26,5 @@ func NewTUN(ifName string) (ifce *Interface, err error) {
 	fmt.Println("Deprecated: NewTUN(..) may be removed in the future. Please use New() instead.")
 	config := Config{DeviceType: TUN}
 	config.Name = ifName
-	return newTUN(config)
+	return openDev(config)
 }

--- a/ipv4_darwin_test.go
+++ b/ipv4_darwin_test.go
@@ -21,6 +21,15 @@ func setupIfce(t *testing.T, self net.IP, remote net.IP, dev string) {
 	}
 }
 
+func teardownIfce(t *testing.T, ifce *Interface) {
+	if err := ifce.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("ifconfig", ifce.Name(), "down").Run(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestP2PTUN(t *testing.T) {
 	var (
 		self   = net.IPv4(10, 0, 42, 1)
@@ -31,6 +40,7 @@ func TestP2PTUN(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating TUN error: %v\n", err)
 	}
+	defer teardownIfce(t, ifce)
 
 	dataCh := make(chan []byte)
 	errCh := make(chan error)

--- a/ipv4_go1.11_test.go
+++ b/ipv4_go1.11_test.go
@@ -1,0 +1,36 @@
+// +build go1.11
+
+package water
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCloseUnblockPendingRead(t *testing.T) {
+	ifce, err := New(Config{DeviceType: TUN})
+	if err != nil {
+		t.Fatalf("creating TUN error: %v\n", err)
+	}
+
+	c := make(chan struct{})
+	go func() {
+		ifce.Read(make([]byte, 1<<16))
+		close(c)
+	}()
+
+	// make sure ifce.Close() happens after ifce.Read() blocks
+	time.Sleep(1 * time.Second)
+
+	ifce.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	select {
+	case <-c:
+		t.Log("Pending Read unblocked")
+	case <-ctx.Done():
+		t.Fatal("Timeouted, pending read blocked")
+	}
+}

--- a/ipv4_linux_test.go
+++ b/ipv4_linux_test.go
@@ -24,6 +24,15 @@ func setupIfce(t *testing.T, ipNet net.IPNet, dev string) {
 	}
 }
 
+func teardownIfce(t *testing.T, ifce *Interface) {
+	if err := ifce.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("ip", "link", "set", ifce.Name(), "down").Run(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestBroadcastTAP(t *testing.T) {
 	var (
 		self = net.IPv4(10, 0, 42, 1)
@@ -35,6 +44,7 @@ func TestBroadcastTAP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating TAP error: %v\n", err)
 	}
+	defer teardownIfce(t, ifce)
 
 	setupIfce(t, net.IPNet{IP: self, Mask: mask}, ifce.Name())
 	startBroadcast(t, brd)

--- a/ipv4_linux_test.go
+++ b/ipv4_linux_test.go
@@ -39,8 +39,9 @@ func TestBroadcastTAP(t *testing.T) {
 	setupIfce(t, net.IPNet{IP: self, Mask: mask}, ifce.Name())
 	startBroadcast(t, brd)
 
-	dataCh := make(chan []byte, 8)
-	startRead(dataCh, ifce)
+	dataCh := make(chan []byte)
+	errCh := make(chan error)
+	startRead(t, ifce, dataCh, errCh)
 
 	timeout := time.NewTimer(8 * time.Second).C
 
@@ -70,6 +71,8 @@ readFrame:
 			}
 			t.Logf("received broadcast frame: %#v\n", buffer)
 			break readFrame
+		case err := <-errCh:
+			t.Fatalf("read error: %v", err)
 		case <-timeout:
 			t.Fatal("Waiting for broadcast packet timeout")
 		}

--- a/ipv4_linux_test.go
+++ b/ipv4_linux_test.go
@@ -4,13 +4,14 @@ import (
 	"net"
 	"os/exec"
 	"testing"
-	"time"
-
-	"github.com/songgao/water/waterutil"
 )
 
-func startBroadcast(t *testing.T, dst net.IP) {
-	if err := exec.Command("ping", "-b", "-c", "4", dst.String()).Start(); err != nil {
+func startPing(t *testing.T, dst net.IP, dashB bool) {
+	params := []string{"-c", "4", dst.String()}
+	if dashB {
+		params = append([]string{"-b"}, params...)
+	}
+	if err := exec.Command("ping", params...).Start(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -46,45 +47,52 @@ func TestBroadcastTAP(t *testing.T) {
 	}
 	defer teardownIfce(t, ifce)
 
+	dataCh, errCh := startRead(t, ifce)
+
 	setupIfce(t, net.IPNet{IP: self, Mask: mask}, ifce.Name())
-	startBroadcast(t, brd)
+	startPing(t, brd, true)
 
-	dataCh := make(chan []byte)
-	errCh := make(chan error)
-	startRead(t, ifce, dataCh, errCh)
+	waitForPingOrBust(t, true, true, self, brd, dataCh, errCh)
+}
 
-	timeout := time.NewTimer(8 * time.Second).C
+func TestBroadcastTUN(t *testing.T) {
+	var (
+		self = net.IPv4(10, 0, 42, 1)
+		mask = net.IPv4Mask(255, 255, 255, 0)
+		brd  = net.IPv4(10, 0, 42, 255)
+	)
 
-readFrame:
-	for {
-		select {
-		case buffer := <-dataCh:
-			ethertype := waterutil.MACEthertype(buffer)
-			if ethertype != waterutil.IPv4 {
-				continue readFrame
-			}
-			if !waterutil.IsBroadcast(waterutil.MACDestination(buffer)) {
-				continue readFrame
-			}
-			packet := waterutil.MACPayload(buffer)
-			if !waterutil.IsIPv4(packet) {
-				continue readFrame
-			}
-			if !waterutil.IPv4Source(packet).Equal(self) {
-				continue readFrame
-			}
-			if !waterutil.IPv4Destination(packet).Equal(brd) {
-				continue readFrame
-			}
-			if waterutil.IPv4Protocol(packet) != waterutil.ICMP {
-				continue readFrame
-			}
-			t.Logf("received broadcast frame: %#v\n", buffer)
-			break readFrame
-		case err := <-errCh:
-			t.Fatalf("read error: %v", err)
-		case <-timeout:
-			t.Fatal("Waiting for broadcast packet timeout")
-		}
+	ifce, err := New(Config{DeviceType: TUN})
+	if err != nil {
+		t.Fatalf("creating TUN error: %v\n", err)
 	}
+	defer teardownIfce(t, ifce)
+
+	dataCh, errCh := startRead(t, ifce)
+
+	setupIfce(t, net.IPNet{IP: self, Mask: mask}, ifce.Name())
+	startPing(t, brd, true)
+
+	waitForPingOrBust(t, false, true, self, brd, dataCh, errCh)
+}
+
+func TestUnicastTUN(t *testing.T) {
+	var (
+		self   = net.IPv4(10, 0, 42, 1)
+		mask   = net.IPv4Mask(255, 255, 255, 0)
+		remote = net.IPv4(10, 0, 42, 2)
+	)
+
+	ifce, err := New(Config{DeviceType: TUN})
+	if err != nil {
+		t.Fatalf("creating TUN error: %v\n", err)
+	}
+	defer teardownIfce(t, ifce)
+
+	dataCh, errCh := startRead(t, ifce)
+
+	setupIfce(t, net.IPNet{IP: self, Mask: mask}, ifce.Name())
+	startPing(t, remote, false)
+
+	waitForPingOrBust(t, false, false, self, remote, dataCh, errCh)
 }

--- a/ipv4_test.go
+++ b/ipv4_test.go
@@ -1,9 +1,7 @@
 package water
 
 import (
-	"context"
 	"testing"
-	"time"
 )
 
 const BUFFERSIZE = 1522
@@ -21,31 +19,4 @@ func startRead(t *testing.T, ifce *Interface, dataCh chan<- []byte, errCh chan<-
 			}
 		}
 	}()
-}
-
-func TestCloseUnblockPendingRead(t *testing.T) {
-	ifce, err := New(Config{DeviceType: TUN})
-	if err != nil {
-		t.Fatalf("creating TUN error: %v\n", err)
-	}
-
-	c := make(chan struct{})
-	go func() {
-		ifce.Read(make([]byte, 1<<16))
-		close(c)
-	}()
-
-	// make sure ifce.Close() happens after ifce.Read() blocks
-	time.Sleep(1 * time.Second)
-
-	ifce.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	select {
-	case <-c:
-		t.Log("Pending Read unblocked")
-	case <-ctx.Done():
-		t.Fatal("Timeouted, pending read blocked")
-	}
 }

--- a/ipv4_test.go
+++ b/ipv4_test.go
@@ -8,14 +8,16 @@ import (
 
 const BUFFERSIZE = 1522
 
-func startRead(ch chan<- []byte, ifce *Interface) {
+func startRead(t *testing.T, ifce *Interface, dataCh chan<- []byte, errCh chan<- error) {
 	go func() {
 		for {
 			buffer := make([]byte, BUFFERSIZE)
 			n, err := ifce.Read(buffer)
-			if err == nil {
+			if err != nil {
+				errCh <- err
+			} else {
 				buffer = buffer[:n:n]
-				ch <- buffer
+				dataCh <- buffer
 			}
 		}
 	}()

--- a/ipv4_test.go
+++ b/ipv4_test.go
@@ -1,12 +1,18 @@
 package water
 
 import (
+	"net"
 	"testing"
+	"time"
+
+	"github.com/songgao/water/waterutil"
 )
 
 const BUFFERSIZE = 1522
 
-func startRead(t *testing.T, ifce *Interface, dataCh chan<- []byte, errCh chan<- error) {
+func startRead(t *testing.T, ifce *Interface) (dataChan <-chan []byte, errChan <-chan error) {
+	dataCh := make(chan []byte)
+	errCh := make(chan error)
 	go func() {
 		for {
 			buffer := make([]byte, BUFFERSIZE)
@@ -19,4 +25,51 @@ func startRead(t *testing.T, ifce *Interface, dataCh chan<- []byte, errCh chan<-
 			}
 		}
 	}()
+	return dataCh, errCh
+}
+
+func waitForPingOrBust(t *testing.T,
+	isTAP bool,
+	expectBroadcast bool,
+	expectSrc net.IP,
+	expectDest net.IP,
+	dataCh <-chan []byte, errCh <-chan error) {
+	waitForPintTimeout := time.NewTimer(8 * time.Second).C
+readFrame:
+	for {
+		select {
+		case buffer := <-dataCh:
+			var packet []byte
+			if isTAP {
+				ethertype := waterutil.MACEthertype(buffer)
+				if ethertype != waterutil.IPv4 {
+					continue readFrame
+				}
+				if expectBroadcast && !waterutil.IsBroadcast(waterutil.MACDestination(buffer)) {
+					continue readFrame
+				}
+				packet = waterutil.MACPayload(buffer)
+			} else {
+				packet = buffer
+			}
+			if !waterutil.IsIPv4(packet) {
+				continue readFrame
+			}
+			if !waterutil.IPv4Source(packet).Equal(expectSrc) {
+				continue readFrame
+			}
+			if !waterutil.IPv4Destination(packet).Equal(expectDest) {
+				continue readFrame
+			}
+			if waterutil.IPv4Protocol(packet) != waterutil.ICMP {
+				continue readFrame
+			}
+			t.Logf("received broadcast frame: %#v\n", buffer)
+			break readFrame
+		case err := <-errCh:
+			t.Fatalf("read error: %v", err)
+		case <-waitForPintTimeout:
+			t.Fatal("Waiting for broadcast packet timeout")
+		}
+	}
 }

--- a/ipv4_windows_test.go
+++ b/ipv4_windows_test.go
@@ -45,7 +45,8 @@ func TestBroadcastTAP(t *testing.T) {
 	startBroadcast(t, brd)
 
 	dataCh := make(chan []byte, 8)
-	startRead(dataCh, ifce)
+	errCh := make(chan error)
+	startRead(t, ifce, dataCh, errCh)
 
 	timeout := time.NewTimer(8 * time.Second).C
 
@@ -75,6 +76,8 @@ readFrame:
 			}
 			t.Logf("received broadcast frame: %#v\n", buffer)
 			break readFrame
+		case err := <-errCh:
+			t.Fatalf("read error: %v", err)
 		case <-timeout:
 			t.Fatal("Waiting for broadcast packet timeout")
 		}

--- a/syscalls_darwin.go
+++ b/syscalls_darwin.go
@@ -59,7 +59,10 @@ type sockaddrCtl struct {
 
 var sockaddrCtlSize uintptr = 32
 
-func newTUN(config Config) (ifce *Interface, err error) {
+func openDev(config Config) (ifce *Interface, err error) {
+	if config.DeviceType != TUN {
+		return nil, errors.New("only tun is implemented on this platform")
+	}
 	var fd int
 	// Supposed to be socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL), but ...
 	//
@@ -111,7 +114,7 @@ func newTUN(config Config) (ifce *Interface, err error) {
 		return nil, fmt.Errorf("error in syscall.Syscall6(syscall.SYS_GETSOCKOPT, ...): %v", err)
 	}
 
-	if err = syscall.SetNonblock(fd, true); err != nil {
+	if err = setNonBlock(fd); err != nil {
 		return nil, fmt.Errorf("setting non-blocking error")
 	}
 
@@ -122,10 +125,6 @@ func newTUN(config Config) (ifce *Interface, err error) {
 			f: os.NewFile(uintptr(fd), string(ifName.name[:])),
 		},
 	}, nil
-}
-
-func newTAP(config Config) (ifce *Interface, err error) {
-	return nil, errors.New("tap interface not implemented on this platform")
 }
 
 // tunReadCloser is a hack to work around the first 4 bytes "packet

--- a/syscalls_darwin_go1.11.go
+++ b/syscalls_darwin_go1.11.go
@@ -1,0 +1,9 @@
+// +build darwin,go1.11
+
+package water
+
+import "syscall"
+
+func setNonBlock(fd int) error {
+	return syscall.SetNonblock(fd, true)
+}

--- a/syscalls_darwin_legacy.go
+++ b/syscalls_darwin_legacy.go
@@ -1,0 +1,10 @@
+// +build darwin,!go1.11
+
+package water
+
+func setNonBlock(fd int) error {
+	// There's a but pre-go1.11 that causes 'resource temporarily unavailable'
+	// error in non-blocking mode. So just skip it here. Close() won't be able
+	// to unblock a pending read, but that's better than being broken.
+	return nil
+}

--- a/syscalls_linux_go1.11.go
+++ b/syscalls_linux_go1.11.go
@@ -1,0 +1,27 @@
+// +build linux,go1.11
+
+package water
+
+import (
+	"os"
+	"syscall"
+)
+
+func openDev(config Config) (ifce *Interface, err error) {
+	var fdInt int
+	if fdInt, err = syscall.Open(
+		"/dev/net/tun", os.O_RDWR|syscall.O_NONBLOCK, 0); err != nil {
+		return nil, err
+	}
+
+	name, err := setupFd(config, uintptr(fdInt))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Interface{
+		isTAP:           config.DeviceType == TAP,
+		ReadWriteCloser: os.NewFile(uintptr(fdInt), "tun"),
+		name:            name,
+	}, nil
+}

--- a/syscalls_linux_legacy.go
+++ b/syscalls_linux_legacy.go
@@ -1,0 +1,26 @@
+// +build linux,!go1.11
+
+package water
+
+import (
+	"os"
+)
+
+func openDev(config Config) (ifce *Interface, err error) {
+	var file *os.File
+	if file, err = os.OpenFile(
+		"/dev/net/tun", os.O_RDWR, 0); err != nil {
+		return nil, err
+	}
+
+	name, err := setupFd(config, file.Fd())
+	if err != nil {
+		return nil, err
+	}
+
+	return &Interface{
+		isTAP:           config.DeviceType == TAP,
+		ReadWriteCloser: file,
+		name:            name,
+	}, nil
+}

--- a/syscalls_other.go
+++ b/syscalls_other.go
@@ -4,10 +4,6 @@ package water
 
 import "errors"
 
-func newTAP(config Config) (ifce *Interface, err error) {
-	return nil, errors.New("tap interface not implemented on this platform")
-}
-
-func newTUN(config Config) (ifce *Interface, err error) {
-	return nil, errors.New("tap interface not implemented on this platform")
+func openDev(config Config) (*Interface, error) {
+	return nil, errors.New("not implemented on this platform")
 }

--- a/syscalls_windows.go
+++ b/syscalls_windows.go
@@ -306,11 +306,3 @@ func openDev(config Config) (ifce *Interface, err error) {
 
 	return nil, errIfceNameNotFound
 }
-
-func newTAP(config Config) (ifce *Interface, err error) {
-	return openDev(config)
-}
-
-func newTUN(config Config) (ifce *Interface, err error) {
-	return openDev(config)
-}


### PR DESCRIPTION
* Before go1.11, we'd get `resource temporarily unavailable` when reading from a non-blocking TUN/TAP fd. So disable non-blocking mode for Go versions before go1.11. (Fixes #57)
* Tests are sometimes flaky on darwin. This is because when process exits, there's a delay in cleaning up the TUN interface. If two consecutive tests run close to each other, we can have multiple TUN interfaces with the same subnet configured, and in the second test we'd miss the packets.
* refactor to better re-use code in tests.

cc @warriorpaw @Gnouc @lixin9311 