### PR TITLE
TAP support for Darwin using tuntaposx

### DIFF
--- a/params_darwin.go
+++ b/params_darwin.go
@@ -1,11 +1,14 @@
 package water
 
+// MacOSDriverProvider enumerates possible MacOS TUN/TAP implementations
+type MacOSDriverProvider int
+
 const (
-	// SystemDriver refers to the default P2P driver
-	SystemDriver = 0
-	// TunTapOSXDriver refers to the third-party tuntaposx driver
+	// MacOSDriverSystem refers to the default P2P driver
+	MacOSDriverSystem MacOSDriverProvider = 0
+	// MacOSDriverTunTapOSX refers to the third-party tuntaposx driver
 	// see https://sourceforge.net/p/tuntaposx
-	TunTapOSXDriver = 1
+	MacOSDriverTunTapOSX MacOSDriverProvider = 1
 )
 
 // PlatformSpecificParams defines parameters in Config that are specific to
@@ -19,7 +22,7 @@ type PlatformSpecificParams struct {
 	Name string
 	// Driver should be set if an alternative driver is desired
 	// e.g. TunTapOSXDriver
-	Driver int
+	Driver MacOSDriverProvider
 }
 
 func defaultPlatformSpecificParams() PlatformSpecificParams {

--- a/params_darwin.go
+++ b/params_darwin.go
@@ -1,10 +1,25 @@
 package water
 
+const (
+	// SystemDriver refers to the default P2P driver
+	SystemDriver = 0
+	// TunTapOSXDriver refers to the third-party tuntaposx driver
+	// see https://sourceforge.net/p/tuntaposx
+	TunTapOSXDriver = 1
+)
+
 // PlatformSpecificParams defines parameters in Config that are specific to
 // macOS. A zero-value of such type is valid, yielding an interface
 // with OS defined name.
 // Currently it is not possible to set the interface name in macOS.
 type PlatformSpecificParams struct {
+	// Name is the name for the interface to be used.
+	// e.g. "tap0"
+	// Only valid if using TunTapOSXDriver.
+	Name string
+	// Driver should be set if an alternative driver is desired
+	// e.g. TunTapOSXDriver
+	Driver int
 }
 
 func defaultPlatformSpecificParams() PlatformSpecificParams {

--- a/syscalls_darwin.go
+++ b/syscalls_darwin.go
@@ -61,11 +61,17 @@ type sockaddrCtl struct {
 var sockaddrCtlSize uintptr = 32
 
 func openDev(config Config) (ifce *Interface, err error) {
-	if config.Driver == TunTapOSXDriver {
+	if config.Driver == MacOSDriverTunTapOSX {
 		return openDevTunTapOSX(config)
-	} else if config.Driver != SystemDriver {
-		return nil, errors.New("unrecognized driver")
 	}
+	if config.Driver == MacOSDriverSystem {
+		return openDevSystem(config)
+	}
+	return nil, errors.New("unrecognized driver")
+}
+
+// openDevSystem opens tun device on system
+func openDevSystem(config Config) (ifce *Interface, err error) {
 	if config.DeviceType != TUN {
 		return nil, errors.New("only tun is implemented for SystemDriver, use TunTapOSXDriver for tap")
 	}
@@ -140,9 +146,11 @@ func openDevTunTapOSX(config Config) (ifce *Interface, err error) {
 
 	if config.DeviceType == TAP && !strings.HasPrefix(config.Name, "tap") {
 		return nil, errors.New("device name does not start with tap when creating a tap device")
-	} else if config.DeviceType == TUN && !strings.HasPrefix(config.Name, "tun") {
+	}
+	if config.DeviceType == TUN && !strings.HasPrefix(config.Name, "tun") {
 		return nil, errors.New("device name does not start with tun when creating a tun device")
-	} else if config.DeviceType != TAP && config.DeviceType != TUN {
+	}
+	if config.DeviceType != TAP && config.DeviceType != TUN {
 		return nil, errors.New("unsupported DeviceType")
 	}
 	if len(config.Name) >= 15 {


### PR DESCRIPTION
TAP mode output, using (mostly) the same code from the Linux example.
```
Yifans-MacBook-Pro:cmd yifangu$ sudo ./cmd 
2019/05/20 17:57:36 Dst: ff:ff:ff:ff:ff:ff
2019/05/20 17:57:36 Src: 72:02:ae:90:f9:4e
2019/05/20 17:57:36 Ethertype: 08 06
2019/05/20 17:57:36 Payload: 00 01 08 00 06 04 00 01 72 02 ae 90 f9 4e c0 a8 08 08 00 00 00 00 00 00 c0 a8 08 08
2019/05/20 17:57:36 Dst: ff:ff:ff:ff:ff:ff
2019/05/20 17:57:36 Src: 72:02:ae:90:f9:4e
2019/05/20 17:57:36 Ethertype: 08 06
2019/05/20 17:57:36 Payload: 00 01 08 00 06 04 00 01 72 02 ae 90 f9 4e c0 a8 08 08 00 00 00 00 00 00 c0 a8 08 08
2019/05/20 17:57:36 Dst: 01:00:5e:00:00:fb
2019/05/20 17:57:36 Src: 72:02:ae:90:f9:4e
2019/05/20 17:57:36 Ethertype: 08 00
2019/05/20 17:57:36 Payload: 45 00 01 f1 f1 79 00 00 ff 11 1e d6 c0 a8 08 08 e0 00 00 fb 14 e9 14 e9 01 dd 42 39 00 00 00 00 00 1c 00 00 00 00 00 01 05 5f 72 61 6f 70 04 5f 74 63 70 05 6c 6f 63 61 6c 00 00 0c 80 01 08 5f 61 69 72 70 6c 61 79 c0 12 00 0c 80 01 08 5f 68 6f 6d 65 6b 69 74 c0 12 00 0c 80 01 08 5f 61 69 72 70 6f 72 74 c0 12 00 0c 80 01 07 5f 72 64 6c 69 6e 6b c0 12 00 0c 80 01 06 5f 75 73 63 61 6e c0 12 00 0c 80 01 07 5f 75 73 63 61 6e 73 c0 12 00 0c 80 01 07 5f 69 70 70 75 73 62 c0 12 00 0c 80 01 08 5f 73 63 61 6e 6e 65 72 c0 12 00 0c 80 01 04 5f 69 70 70 c0 12 00 0c 80 01 05 5f 69 70 70 73 c0 12 00 0c 80 01 08 5f 70 72 69 6e 74 65 72 c0 12 00 0c 80 01 0f 5f 70 64 6c 2d 64 61 74 61 73 74 72 65 61 6d c0 12 00 0c 80 01 04 5f 70 74 70 c0 12 00 0c 80 01 0d 5f 61 70 70 6c 65 2d 6d 6f 62 64 65 76 c0 12 00 0c 80 01 08 39 37 39 37 30 38 32 65 04 5f 73 75 62 0e 5f 61 70 70 6c 65 2d 6d 6f 62 64 65 76 32 c0 12 00 0c 80 01 0f 5f 61 70 70 6c 65 2d 70 61 69 72 61 62 6c 65 c0 12 00 0c 80 01 c0 fe 00 0c 80 01 05 5f 64 61 61 70 c0 12 00 0c 80 01 0d 5f 74 6f 75 63 68 2d 72 65 6d 6f 74 65 c0 12 00 0c 80 01 c0 22 00 0c 80 01 c0 0c 00 0c 80 01 0b 5f 67 6f 6f 67 6c 65 63 61 73 74 c0 12 00 0c 80 01 0f 5f 63 6f 6d 70 61 6e 69 6f 6e 2d 6c 69 6e 6b c0 12 00 0c 80 01 0b 5f 61 66 70 6f 76 65 72 74 63 70 c0 12 00 0c 80 01 04 5f 73 6d 62 c0 12 00 0c 80 01 04 5f 72 66 62 c0 12 00 0c 80 01 06 5f 61 64 69 73 6b c0 12 00 0c 80 01 00 00 29 05 a0 00 00 11 94 00 12 00 04 00 0e 00 f2 f4 0f 24 30 d3 cb 72 02 ae 90 f9 4e
```

example configuration
```
config := water.Config{
	DeviceType: water.TAP,
	PlatformSpecificParams: water.PlatformSpecificParams{
		Driver: water.TunTapOSXDriver,
		Name:   "tap3",
	},
}
```