### PR TITLE
Windows: fix syscall.ERROR_MORE_DATA

### DIFF
--- a/syscalls_windows.go
+++ b/syscalls_windows.go
@@ -114,7 +114,10 @@ func (f *wfile) Write(b []byte) (int, error) {
 	}
 	var n uint32
 	err := syscall.WriteFile(f.fd, b, &n, f.wo)
-	if err != nil && err != syscall.ERROR_IO_PENDING {
+	switch err {
+	case syscall.ERROR_IO_PENDING, syscall.ERROR_MORE_DATA:
+		return getOverlappedResult(f.fd, f.wo)
+	default:
 		return int(n), err
 	}
 	return getOverlappedResult(f.fd, f.wo)
@@ -129,7 +132,10 @@ func (f *wfile) Read(b []byte) (int, error) {
 	}
 	var done uint32
 	err := syscall.ReadFile(f.fd, b, &done, f.ro)
-	if err != nil && err != syscall.ERROR_IO_PENDING {
+	switch err {
+	case syscall.ERROR_IO_PENDING, syscall.ERROR_MORE_DATA:
+		return getOverlappedResult(f.fd, f.wo)
+	default:
 		return int(done), err
 	}
 	return getOverlappedResult(f.fd, f.ro)

--- a/syscalls_windows.go
+++ b/syscalls_windows.go
@@ -128,7 +128,9 @@ func (f *wfile) Read(b []byte) (n int, err error) {
 	defer f.rl.Unlock()
 
 	if err := resetEvent(f.ro.HEvent); err != nil {
-		return 0, err
+		if err != syscall.ERROR_MORE_DATA {
+			return 0, err
+		}
 	}
 	for {
 		var done uint32


### PR DESCRIPTION
The `syscall.ERROR_MORE_DATA` code is not a true error condition on Windows and shouldn't be treated as such when performing reads/writes. This PR now correctly handles this condition, reading the rest of the available buffer before returning.