### PR TITLE
Windows: don't trip over empty HardwareAddr when enumerating interfaces

### DIFF
--- a/syscalls_windows.go
+++ b/syscalls_windows.go
@@ -298,6 +298,9 @@ func openDev(config Config) (ifce *Interface, err error) {
 	}
 
 	for _, v := range ifces {
+		if len(v.HardwareAddr) < 6 {
+			continue
+		}
 		if bytes.Equal(v.HardwareAddr[:6], mac[:6]) {
 			ifce.name = v.Name
 			return


### PR DESCRIPTION
Some interfaces do not have a `HardwareAddr`, e.g. L2TP/IPsec miniport interfaces. Currently when Water tries to enumerate through these interfaces, a `panic` is masked by a `recover()` when comparing the `v.HardwareAddr` slices which go out-of-bounds.

This PR fixes that.