### PR TITLE
Fix MacOS integer contsant overflow compilation error

### DIFF
--- a/syscalls_darwin.go
+++ b/syscalls_darwin.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"strconv"
 	"strings"

--- a/syscalls_darwin.go
+++ b/syscalls_darwin.go
@@ -85,7 +85,7 @@ func openDevSystem(config Config) (ifce *Interface, err error) {
 			return nil, fmt.Errorf("Interface name must be utun[0-9]+")
 		}
 		ifIndex, err = strconv.Atoi(config.Name[len(utunPrefix):])
-		if err != nil || ifIndex < 0 || ifIndex > math.MaxUint32-1 {
+		if err != nil || ifIndex < 0 {
 			return nil, fmt.Errorf("Interface name must be utun[0-9]+")
 		}
 	}


### PR DESCRIPTION
The line `ifIndex > math.MaxUint32-1` throws a compilation error where `int` is 32 bit since `int32` is signed and cannot go above 2^31 - 1.

However, I'm really curious about the original intent of this check, under what circumstances does `ifIndex` exceed  `MaxUint32 - 1` if `int` was `int64`?