### PR TITLE
Change component ID in example for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ import (
 func main() {
 	ifce, err := water.New(water.Config{
 		DeviceType: water.TAP,
+		PlatformSpecificParams: water.PlatformSpecificParams{
+			ComponentID: "root\\tap0901",
+		},
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Running windows 10, I had to add the lines

```go
PlatformSpecificParams: water.PlatformSpecificParams{
	ComponentID: "root\\tap0901",
},
```
in order to get it to work. I have added this to the readme for others to see. If this is somehow an issue with only my computer or installation and other users don't need to do this, please let me know, however I don't know how that would be the case.