### PR TITLE
linux: added support for frames with info

### DIFF
--- a/params_linux.go
+++ b/params_linux.go
@@ -38,6 +38,12 @@ type PlatformSpecificParams struct {
 	// uses multiple file descriptors (queues) to parallelize packets sending
 	// or receiving.
 	MultiQueue bool
+
+	// If PacketInfo is set the frame format is:
+	// 	 	Flags [2 bytes]
+	// 		Proto [2 bytes]
+	// 		Raw protocol(IP, IPv6, etc) frame.
+	PacketInfo bool
 }
 
 func defaultPlatformSpecificParams() PlatformSpecificParams {

--- a/syscalls_linux.go
+++ b/syscalls_linux.go
@@ -29,7 +29,7 @@ func ioctl(fd uintptr, request uintptr, argp uintptr) error {
 }
 
 func setupFd(config Config, fd uintptr) (name string, err error) {
-	var flags uint16 = cIFFNOPI
+	var flags uint16
 	if config.DeviceType == TUN {
 		flags |= cIFFTUN
 	} else {
@@ -38,7 +38,9 @@ func setupFd(config Config, fd uintptr) (name string, err error) {
 	if config.PlatformSpecificParams.MultiQueue {
 		flags |= cIFFMULTIQUEUE
 	}
-
+	if !config.PlatformSpecificParams.PacketInfo {
+		flags |= cIFFNOPI
+	}
 	if name, err = createInterface(fd, config.Name, flags); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Instead of defaulting to frames with no packet information, I added a flag that lets the user decide. 